### PR TITLE
feat: add BOOTLOADER command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,6 @@ python tools/flash_firmware.py --release latest --port /dev/cu.usbmodem1101
 python tools/flash_firmware.py --release latest --erase-nvs
 ```
 
-If the device is not detected, hold **BOOT** while pressing **RESET** to enter download mode.
-
 ### Build from Source
 
 Requires [PlatformIO](https://platformio.org/) with ESP-IDF framework.
@@ -169,7 +167,7 @@ git submodule update --init --recursive
 # Build
 ~/.platformio/penv/bin/pio run
 
-# Flash
+# Flash (badge must be in download mode: serial BOOTLOADER or BOOT+RESET)
 ~/.platformio/penv/bin/pio run -t upload
 
 # Monitor (115200 baud)
@@ -199,6 +197,21 @@ Or via Kconfig menuconfig:
 ~/.platformio/penv/bin/pio run -t menuconfig
 ```
 
+### Flash from Source
+
+#### Enable Bootloader
+
+1. Hold **BOOT** while pressing **RESET** to enter download mode.
+
+**or** via serial interface:
+
+1. `AUTH <pin>`  authenticates; `BOOTLOADER` reboots into USB download mode.
+
+> Note: The ESP32-S3 USB-serial/JTAG port changes enumeration suffix between app mode and download mode.
+
+#### Upload firmware
+
+2. `pio run -t upload` — PlatformIO auto-detects the port, uploads firmware and triggers reset via `esptool`.
 ### Factory Reset on Flag Change
 
 Switching `DEBUG_MODE` or `FEATURE_SECURE_SERIAL` between builds and reflashing

--- a/components/cdc_os_ui/src/AppUi.cpp
+++ b/components/cdc_os_ui/src/AppUi.cpp
@@ -45,6 +45,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_timer.h"
+#include "soc/rtc_cntl_reg.h"
 
 namespace cdc::ui {
 
@@ -52,7 +53,7 @@ namespace cdc::ui {
 
 static constexpr uint8_t MAIN_MENU_MAX_ITEMS = 16;
 static constexpr uint8_t MAIN_MENU_FIXED_COUNT = 2;  // Tools + Settings
-static constexpr uint8_t TOOLS_FIXED_COUNT = 4;       // Modules, WiFi, Bluetooth, Expert
+static constexpr uint8_t TOOLS_FIXED_COUNT = 5;       // Modules, WiFi, Bluetooth, Expert, Bootloader
 static constexpr uint8_t TOOLS_MAX_ITEMS = 16;
 
 static constexpr uint32_t INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
@@ -379,6 +380,7 @@ void rebuildToolsMenu() {
     auto* ble = hal::getBluetoothControllerInstance();
     s_toolsItems[2] = {tr(StringId::BLUETOOTH), static_cast<uint8_t>(ble && ble->isEnabled() ? '*' : 0), false, nullptr};
     s_toolsItems[3] = {tr(StringId::EXPERT), 0, false, nullptr};
+    s_toolsItems[4] = {tr(StringId::BOOTLOADER), 0, false, nullptr};
 
     auto& moduleReg = core::ModuleRegistry::instance();
     s_toolsModuleCount = moduleReg.getMenuItems(
@@ -456,6 +458,10 @@ static void onToolsSelect(uint16_t index, void* userData) {
         case 1: showWifiMainMenu(); return;
         case 2: showBluetoothMenu(); return;
         case 3: showExpertMenu(); return;
+        case 4:  // Bootloader
+            REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+            esp_restart();
+            return;
     }
 
     uint8_t moduleIdx = index - TOOLS_FIXED_COUNT;

--- a/components/cdc_ui/include/cdc_ui/I18n.h
+++ b/components/cdc_ui/include/cdc_ui/I18n.h
@@ -189,6 +189,9 @@ enum class StringId : uint16_t {
     QR_ERROR,
     NO_DATA,
 
+    // === Bootloader ===
+    BOOTLOADER,
+
     // Core string count - modules start from here
     CORE_COUNT
 };

--- a/components/cdc_ui/src/I18n.cpp
+++ b/components/cdc_ui/src/I18n.cpp
@@ -319,6 +319,7 @@ void I18n::initCoreStrings() {
     REG(TR01_CACHE_CLEANUP, "TR01 Cache Cleanup",   "TR01 Cache aufraeumen");
     REG(EXPERT,             "Expert",               "Experte");
     REG(EXPERT_WARNING,     "Caution",              "Vorsicht");
+    REG(BOOTLOADER,         "Bootloader",           "Bootloader");
     REG(TASK_WORKING,       "Please wait",          "Bitte warten");
     REG(USB_REPLUG_REQUIRED,"USB replug may be needed", "USB replug ggf. noetig");
     REG(SLEEP,              "Sleep",                "Schlafmodus");

--- a/components/serial_cmd/src/SerialCmd.cpp
+++ b/components/serial_cmd/src/SerialCmd.cpp
@@ -20,6 +20,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_memory_utils.h"
+#include "soc/rtc_cntl_reg.h"
 #include <cstring>
 #include <cctype>
 #include <cstdlib>
@@ -560,6 +561,19 @@ static void cmdReboot(const char* args) {
     Console::printf("Rebooting...\r\n");
     Console::flush();
     vTaskDelay(pdMS_TO_TICKS(100));
+    esp_restart();
+}
+
+/**
+ * \brief Reboots the device into USB download (bootloader) mode.
+ * \param args Unused command arguments.
+ */
+static void cmdBootloader(const char* args) {
+    (void)args;
+    Console::printf("Rebooting into download mode...\r\n");
+    Console::flush();
+    vTaskDelay(pdMS_TO_TICKS(100));
+    REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
     esp_restart();
 }
 
@@ -1656,6 +1670,7 @@ void SerialCmd::registerBuiltinCommands() {
     reg.registerCommand({"MEMINFO", "Show detailed memory + task info", cmdMemInfo, "system", false});
     reg.registerCommand({"ERROR_LOG", "Show error log (CLEAR to reset)", cmdErrorLog, "system", false});
     reg.registerCommand({"REBOOT", "Restart the device", cmdReboot, "system", true});
+    reg.registerCommand({"BOOTLOADER", "Reboot into USB download mode", cmdBootloader, "system", true});
 
     // NVS commands
     reg.registerCommand({"NVS_LIST", "List NVS entries [namespace]", cmdNvsList, "nvs", false});

--- a/docs/SERIAL_COMMANDS.md
+++ b/docs/SERIAL_COMMANDS.md
@@ -34,6 +34,7 @@ Home Assistant module surface, and the factory-wipe commands.
 | `ERROR_LOG` | Show error log |
 | `ERROR_LOG CLEAR` | Clear error log |
 | `REBOOT` | Restart the device `[AUTH]` |
+| `BOOTLOADER` | Reboot into USB download mode `[AUTH]` |
 
 ## Time
 


### PR DESCRIPTION
- Add `BOOTLOADER` serial command that reboots into USB download mode via `REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT)`.
- Put "Bootloader" entry to Tools menu in the UI.
- Update `README.md`; "Flash from Source" section moved below "Build from source".